### PR TITLE
Repair build and get it to work with appkit 4.0.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,18 +58,17 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.2"
-//    implementation(group: "org.ergoplatform", name: "ergo-appkit_2.11", version: "3.1.1-RC3", configuration: "compile") {
-//        sourceSets {
-//         removeAll()
-//        }
-//    }
+    implementation ('org.ergoplatform:ergo-appkit_2.11:4.0.4') {
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
+    }
+    implementation "org.bouncycastle:bcprov-jdk15to18:1.66"
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/src/main/java/org/ergoplatform/android/ErgoFacade.kt
+++ b/app/src/main/java/org/ergoplatform/android/ErgoFacade.kt
@@ -37,8 +37,8 @@ class ErgoFacade {
             )
             val prover = ctx.newProverBuilder()
                .withMnemonic(
-                  nodeConf.wallet.mnemonic,
-                  nodeConf.wallet.password
+                  SecretString.create(nodeConf.wallet.mnemonic),
+                  SecretString.create(nodeConf.wallet.password)
                )
                .build()
             val txB = ctx.newTxBuilder()

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.60'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
-        jcenter()
-        
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,8 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
This pulls in the current appkit 4.0.4, replaces the BouncyCastle dependency with the actual version that is working on Java 7 and 8 and updates Gradle and Kotlin in order to work with the latest Android Studio.

HTH